### PR TITLE
Issue #15 and #10: use https by default

### DIFF
--- a/src/USPSBase.php
+++ b/src/USPSBase.php
@@ -12,7 +12,7 @@ namespace USPS;
  */
 abstract class USPSBase
 {
-    const LIVE_API_URL = 'http://production.shippingapis.com/ShippingAPI.dll';
+    const LIVE_API_URL = 'https://secure.shippingapis.com/ShippingAPI.dll';
     const TEST_API_URL = 'http://production.shippingapis.com/ShippingAPITest.dll';
 
     /**


### PR DESCRIPTION
I recently learned that some of the API methods are supported on the https secure domain.

I'm not 100% sure that this should be merged yet. I did email the USPS support folks just suggesting and asking what the status of HTTPS support is. I'll follow up if I learn it works for everything.