### PR TITLE
strict comparison for getting array value by key

### DIFF
--- a/src/USPSBase.php
+++ b/src/USPSBase.php
@@ -431,7 +431,7 @@ abstract class USPSBase
     protected function getValueByKey($array, $key)
     {
         foreach ($array as $k => $each) {
-            if ($k == $key) {
+            if ($k === $key) {
                 return $each;
             }
 


### PR DESCRIPTION
When getting errors, loose equality sometimes matches the 0 index of the array of errors and not the nested 'Errors' key.  This results in an index 'Number' not found exception on `$this->setErrorCode($errorInfo['Number']);`