### PR TITLE
Added ability to include Revision tag for AddressVerify requests

### DIFF
--- a/src/AddressVerify.php
+++ b/src/AddressVerify.php
@@ -17,6 +17,10 @@ class AddressVerify extends USPSBase
      */
     protected $apiVersion = 'Verify';
     /**
+     * @var string - revision version for including additional response fields
+     */
+    protected $revision = '';
+    /**
      * @var array - list of all addresses added so far
      */
     protected $addresses = [];
@@ -38,7 +42,8 @@ class AddressVerify extends USPSBase
      */
     public function getPostFields()
     {
-        return $this->addresses;
+        $postFields = !empty($this->revision) ? ['Revision' => $this->revision] : [];
+        return array_merge($postFields, $this->addresses);
     }
 
     /**
@@ -52,5 +57,19 @@ class AddressVerify extends USPSBase
         $packageId = $id !== null ? $id : ((count($this->addresses) + 1));
 
         $this->addresses['Address'][] = array_merge(['@attributes' => ['ID' => $packageId]], $data->getAddressInfo());
+    }
+
+    /**
+     * Set the revision value
+     *
+     * @param string|int $value
+     *
+     * @return object AddressVerify
+     */
+    public function setRevision($value)
+    {
+        $this->revision = (string)$value;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Added the ability to include the `Revision` XML tag. Without `<Revision>1</Revision>` the response only includes the validated address, and does not include all response fields, which are useful for handling various validation cases (e.g. street address is correct but missing a unit number).